### PR TITLE
Show content cards only when data is ready

### DIFF
--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -46,14 +46,14 @@
             </div>
           </q-card-section>
         </q-card>
-        <q-card class="table-of-content">
+        <q-card v-if="isJsonLoaded" class="table-of-content">
           <q-card-section>
             <table-of-content />
           </q-card-section>
         </q-card>
       </div>
       <div class="col-sm-12 col-md-7">
-        <q-card class="collection-content">
+        <q-card v-if="isJsonLoaded" class="collection-content">
           <q-card-section>
             <collection-description
               :info="this.$store.getters['collection/getCollection'].info"
@@ -158,6 +158,11 @@ export default {
         { method: 'PATCH', value: '#9e9e9e' },
         { method: 'DELETE', value: '#C10015' }
       ]
+    }
+  },
+  computed: {
+    isJsonLoaded () {
+      return this.$store.getters['collection/getCollection'].item.length !== 0
     }
   },
   methods: {


### PR DESCRIPTION
### General 

closes #13 

- Show content card only when the user load a json file, this avoid that it shows empty.

![image](https://user-images.githubusercontent.com/26756070/95002625-1f218d00-05a4-11eb-8dfc-1a4e9a166d03.png)


### Type

> ℹ️  What types of changes does your code introduce?

> 👉 _Put an `x` in the boxes that apply_

- [x] Fix
- [ ] Feature

### Describe the changes here (summarized)

- Added computed property that manage the current json file loaded state.
- Added validation to q-card for render or not depending of the value of the computed property described above.
